### PR TITLE
RA-25 moved the seekBar to initUI

### DIFF
--- a/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/IngredientsAdapter.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/IngredientsAdapter.kt
@@ -47,8 +47,8 @@ class IngredientsAdapter(private val dataSet: List<Ingredient>?) :
         }
     }
 
-    fun updateIngredients(process: Int) {
-        quantity = process
+    fun updateIngredients(process: Int?) {
+        quantity = process ?: 1
     }
 
     override fun getItemCount() = dataSet?.size ?: 0

--- a/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/IngredientsAdapter.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/IngredientsAdapter.kt
@@ -47,8 +47,8 @@ class IngredientsAdapter(private val dataSet: List<Ingredient>?) :
         }
     }
 
-    fun updateIngredients(process: Int?) {
-        quantity = process ?: 1
+    fun updateIngredients(process: Int) {
+        quantity = process
     }
 
     override fun getItemCount() = dataSet?.size ?: 0

--- a/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/RecipeFragment.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/RecipeFragment.kt
@@ -63,10 +63,10 @@ class RecipeFragment : Fragment() {
         setPaddingIngredientListLayout()
 
         viewModel.recipeState.observe(viewLifecycleOwner) { state ->
-            val recipe = state?.recipe
+            val recipe = state.recipe
             val customAdapterIngredient = IngredientsAdapter(recipe?.ingredients)
             val customAdapterMethod = MethodAdapter(recipe?.method)
-            customAdapterIngredient.updateIngredients(state?.numberServings)
+            customAdapterIngredient.updateIngredients(state.numberServings)
             customAdapterIngredient.notifyDataSetChanged()
 
             with(recipeBinding) {

--- a/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/RecipeFragment.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/RecipeFragment.kt
@@ -1,6 +1,5 @@
 package com.example.recipeapp.ui.recipes.recipe
 
-import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -8,7 +7,7 @@ import android.view.ViewGroup
 import android.widget.SeekBar
 import androidx.core.view.setPadding
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
 import com.example.recipeapp.ARG_RECIPE_ID
 import com.example.recipeapp.R
 import com.example.recipeapp.databinding.FragmentRecipeBinding
@@ -16,7 +15,7 @@ import com.google.android.material.divider.MaterialDividerItemDecoration
 
 class RecipeFragment : Fragment() {
 
-    private val viewModel: RecipeViewModel by activityViewModels()
+    private val viewModel: RecipeViewModel by viewModels()
 
     private val recipeBinding: FragmentRecipeBinding by lazy {
         FragmentRecipeBinding.inflate(layoutInflater)
@@ -60,6 +59,7 @@ class RecipeFragment : Fragment() {
             }
         )
 
+
         setPaddingIngredientListLayout()
 
         viewModel.recipeState.observe(viewLifecycleOwner) { state ->
@@ -67,7 +67,6 @@ class RecipeFragment : Fragment() {
             val customAdapterIngredient = IngredientsAdapter(recipe?.ingredients)
             val customAdapterMethod = MethodAdapter(recipe?.method)
             customAdapterIngredient.updateIngredients(state.numberServings)
-            customAdapterIngredient.notifyDataSetChanged()
 
             with(recipeBinding) {
                 rvIngredients.adapter = customAdapterIngredient
@@ -83,10 +82,10 @@ class RecipeFragment : Fragment() {
                     ibFavorites.setImageResource(R.drawable.ic_heart)
                 else
                     ibFavorites.setImageResource(R.drawable.ic_heart_empty)
-                ibFavorites.setOnClickListener {
-                    viewModel.onFavoritesClicked(recipe?.id)
-                }
             }
+        }
+        recipeBinding.ibFavorites.setOnClickListener {
+            viewModel.onFavoritesClicked(recipeId)
         }
 
         setDivider()

--- a/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/RecipeViewModel.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/RecipeViewModel.kt
@@ -31,7 +31,7 @@ class RecipeViewModel(private val application: Application) : AndroidViewModel(a
         } catch (e: Exception) {
             Log.e("!!!", e.stackTrace.toString())
         }
-        _recipeState.value = _recipeState.value?.copy(
+        _recipeState.value = recipeState.value?.copy(
             recipe = recipe,
             isFavorites = isFavorite,
             recipeImage = drawable
@@ -61,11 +61,11 @@ class RecipeViewModel(private val application: Application) : AndroidViewModel(a
         }
         setFavorites(newSet)
         isFavorites = getFavorites().toList().contains(recipeId.toString())
-        _recipeState.value = _recipeState.value?.copy(isFavorites = isFavorites)
+        _recipeState.value = recipeState.value?.copy(isFavorites = isFavorites)
     }
 
     fun changeNumberOfServing(progress: Int) {
-        _recipeState.value = _recipeState.value?.copy(numberServings = progress)
+        _recipeState.value = recipeState.value?.copy(numberServings = progress)
     }
 
     data class RecipeUiState(

--- a/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/RecipeViewModel.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/RecipeViewModel.kt
@@ -64,6 +64,10 @@ class RecipeViewModel(private val application: Application) : AndroidViewModel(a
         _recipeState.value = _recipeState.value?.copy(isFavorites = isFavorites)
     }
 
+    fun changeNumberOfServing(progress: Int) {
+        _recipeState.value = _recipeState.value?.copy(numberServings = progress)
+    }
+
     data class RecipeUiState(
 
         val recipe: Recipe? = null,

--- a/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/RecipeViewModel.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/RecipeViewModel.kt
@@ -16,7 +16,7 @@ import java.io.InputStream
 class RecipeViewModel(private val application: Application) : AndroidViewModel(application) {
 
     private val _recipeState = MutableLiveData(RecipeUiState())
-    val recipeState: LiveData<RecipeUiState?> get() = _recipeState
+    val recipeState: LiveData<RecipeUiState> get() = _recipeState
 
     fun loadRecipe(recipeId: Int?) {
         //TODO `load from network`


### PR DESCRIPTION
 viewModel.recipeState.observe(viewLifecycleOwner) { state ->
            val recipe = state.recipe
            val customAdapterIngredient = IngredientsAdapter(recipe?.ingredients)
            val customAdapterMethod = MethodAdapter(recipe?.method)
            customAdapterIngredient.updateIngredients(state.numberServings)
            customAdapterIngredient.notifyDataSetChanged()
Иван, у меня вопрос этот notifyDataSetChanged() вообще здесь ну или где то еще, в нашем случае вообще нужен?
Без него точно также все меняется.
Мне кажется он нужен только если список объектов  изменился. В нашем случае список не меняется. Или я не правильно думаю?

Код добавления паддинга для listIngedient глаза мозолил, вынес в отдельную функцию.
По хорошему наверное и seekBar можно получить в отдельной функции

Еще не доходит как работает эта строчка 
private val viewModel: RecipeViewModel by activityViewModels()
Читал про делегаты, если by lazy я понял, то с этим не доходит. 


