### PR TITLE
RA-27 create RecipeRepository and ViewModel for all fragments

### DIFF
--- a/app/src/main/java/com/example/recipeapp/Constants.kt
+++ b/app/src/main/java/com/example/recipeapp/Constants.kt
@@ -2,5 +2,3 @@ package com.example.recipeapp
 
 const val ARG_CATEGORY_ID = "ARG_CATEGORY_ID"
 const val ARG_RECIPE_ID = "ARG_RECIPE_ID"
-const val PREF_FAVORITE_KEY = "favoritesId"
-const val PREF_FILE_NAME = "preferencesFavoritesId"

--- a/app/src/main/java/com/example/recipeapp/Constants.kt
+++ b/app/src/main/java/com/example/recipeapp/Constants.kt
@@ -1,9 +1,6 @@
 package com.example.recipeapp
 
 const val ARG_CATEGORY_ID = "ARG_CATEGORY_ID"
-const val ARG_CATEGORY_NAME = "ARG_CATEGORY_NAME"
-const val ARG_CATEGORY_IMAGE_URL = "ARG_CATEGORY_IMAGE_URL"
-const val ARG_RECIPE = "ARG_RECIPE"
 const val ARG_RECIPE_ID = "ARG_RECIPE_ID"
 const val PREF_FAVORITE_KEY = "favoritesId"
 const val PREF_FILE_NAME = "preferencesFavoritesId"

--- a/app/src/main/java/com/example/recipeapp/Constants.kt
+++ b/app/src/main/java/com/example/recipeapp/Constants.kt
@@ -1,4 +1,8 @@
 package com.example.recipeapp
+object Constants {
+    const val ARG_CATEGORY_ID = "ARG_CATEGORY_ID"
+    const val ARG_RECIPE_ID = "ARG_RECIPE_ID"
+    const val PREF_FAVORITE_KEY = "favoritesId"
+    const val PREF_FILE_NAME = "preferencesFavoritesId"
+}
 
-const val ARG_CATEGORY_ID = "ARG_CATEGORY_ID"
-const val ARG_RECIPE_ID = "ARG_RECIPE_ID"

--- a/app/src/main/java/com/example/recipeapp/data/FavoritesLocalDataSources.kt
+++ b/app/src/main/java/com/example/recipeapp/data/FavoritesLocalDataSources.kt
@@ -1,0 +1,31 @@
+package com.example.recipeapp.data
+
+import android.content.Context
+import android.content.Context.MODE_PRIVATE
+import android.content.SharedPreferences
+
+
+class FavoritesLocalDataSources(
+    private val context: Context,
+) {
+
+    fun getFavorites(): MutableSet<String> {
+        val sharedPref: SharedPreferences =
+            context.getSharedPreferences(PREF_FILE_NAME, MODE_PRIVATE)
+        val setId = sharedPref.getStringSet(PREF_FAVORITE_KEY, emptySet())
+        val mutableSteId = HashSet<String>(setId)
+        return mutableSteId
+    }
+
+    fun setFavorites(setFavoriteId: Set<String>?) {
+        val sharedPref: SharedPreferences =
+            context.getSharedPreferences(PREF_FILE_NAME, MODE_PRIVATE)
+                ?: return
+        sharedPref.edit()?.putStringSet(PREF_FAVORITE_KEY, setFavoriteId)?.apply()
+    }
+
+    companion object {
+        const val PREF_FAVORITE_KEY = "favoritesId"
+        const val PREF_FILE_NAME = "preferencesFavoritesId"
+    }
+}

--- a/app/src/main/java/com/example/recipeapp/data/FavoritesLocalDataSources.kt
+++ b/app/src/main/java/com/example/recipeapp/data/FavoritesLocalDataSources.kt
@@ -1,31 +1,19 @@
 package com.example.recipeapp.data
 
-import android.content.Context
-import android.content.Context.MODE_PRIVATE
 import android.content.SharedPreferences
-
+import com.example.recipeapp.Constants.PREF_FAVORITE_KEY
 
 class FavoritesLocalDataSources(
-    private val context: Context,
+    private val sharedPreferences: SharedPreferences
 ) {
 
     fun getFavorites(): MutableSet<String> {
-        val sharedPref: SharedPreferences =
-            context.getSharedPreferences(PREF_FILE_NAME, MODE_PRIVATE)
-        val setId = sharedPref.getStringSet(PREF_FAVORITE_KEY, emptySet())
+        val setId = sharedPreferences.getStringSet(PREF_FAVORITE_KEY, emptySet())
         val mutableSteId = HashSet<String>(setId)
         return mutableSteId
     }
 
     fun setFavorites(setFavoriteId: Set<String>?) {
-        val sharedPref: SharedPreferences =
-            context.getSharedPreferences(PREF_FILE_NAME, MODE_PRIVATE)
-                ?: return
-        sharedPref.edit()?.putStringSet(PREF_FAVORITE_KEY, setFavoriteId)?.apply()
-    }
-
-    companion object {
-        const val PREF_FAVORITE_KEY = "favoritesId"
-        const val PREF_FILE_NAME = "preferencesFavoritesId"
+        sharedPreferences.edit()?.putStringSet(PREF_FAVORITE_KEY, setFavoriteId)?.apply()
     }
 }

--- a/app/src/main/java/com/example/recipeapp/data/FavoritesRepository.kt
+++ b/app/src/main/java/com/example/recipeapp/data/FavoritesRepository.kt
@@ -4,11 +4,15 @@ class FavoritesRepository(
     private val favoritesLocalDataSources: FavoritesLocalDataSources,
 ) {
 
-    fun getRecipeData():MutableSet<String>{
+    fun getRecipeData(): MutableSet<String> {
         return favoritesLocalDataSources.getFavorites()
     }
 
-    fun setRecipeData(setFavoriteId: Set<String>?){
+    fun setRecipeData(setFavoriteId: Set<String>?) {
         favoritesLocalDataSources.setFavorites(setFavoriteId)
+    }
+
+    fun checkIsFavorites(recipeId: Int?): Boolean {
+        return getRecipeData().toList().contains(recipeId.toString())
     }
 }

--- a/app/src/main/java/com/example/recipeapp/data/FavoritesRepository.kt
+++ b/app/src/main/java/com/example/recipeapp/data/FavoritesRepository.kt
@@ -1,0 +1,14 @@
+package com.example.recipeapp.data
+
+class FavoritesRepository(
+    private val favoritesLocalDataSources: FavoritesLocalDataSources,
+) {
+
+    fun getRecipeData():MutableSet<String>{
+        return favoritesLocalDataSources.getFavorites()
+    }
+
+    fun setRecipeData(setFavoriteId: Set<String>?){
+        favoritesLocalDataSources.setFavorites(setFavoriteId)
+    }
+}

--- a/app/src/main/java/com/example/recipeapp/data/RecipeRepository.kt
+++ b/app/src/main/java/com/example/recipeapp/data/RecipeRepository.kt
@@ -1,0 +1,47 @@
+package com.example.recipeapp.data
+
+import android.content.Context
+import android.content.Context.MODE_PRIVATE
+import android.content.SharedPreferences
+import com.example.recipeapp.PREF_FAVORITE_KEY
+import com.example.recipeapp.PREF_FILE_NAME
+import com.example.recipeapp.model.Category
+import com.example.recipeapp.model.Recipe
+
+class RecipeRepository(
+    private val recipe: STUB = STUB,
+    private val context: Context
+) {
+
+    private val category = recipe.getCategories()
+    private val burgerRecipes = recipe.getRecipe()
+
+    fun getCategories() = category
+
+    fun getRecipe() = burgerRecipes
+
+    fun getRecipeById(id: Int?): Recipe? {
+        return burgerRecipes.find { it.id == id }
+    }
+
+    fun getCategoryById(id: Int?): Category? {
+        return category.find { it.id == id }
+    }
+
+    fun getRecipesByIds(favoritesListIdInt: Set<Int>): List<Recipe> {
+        return burgerRecipes.filter { favoritesListIdInt.contains(it.id) }
+    }
+
+    fun getFavorites(): MutableSet<String> {
+        val sharedPref: SharedPreferences = context.getSharedPreferences(PREF_FILE_NAME, MODE_PRIVATE)
+        val setId = sharedPref.getStringSet(PREF_FAVORITE_KEY, emptySet())
+        val mutableSteId = HashSet<String>(setId)
+        return mutableSteId
+    }
+
+    fun setFavorites(setFavoriteId: Set<String>?) {
+        val sharedPref:SharedPreferences = context.getSharedPreferences(PREF_FILE_NAME, MODE_PRIVATE)
+            ?: return
+        sharedPref.edit()?.putStringSet(PREF_FAVORITE_KEY, setFavoriteId)?.apply()
+    }
+}

--- a/app/src/main/java/com/example/recipeapp/data/RecipeRepository.kt
+++ b/app/src/main/java/com/example/recipeapp/data/RecipeRepository.kt
@@ -1,16 +1,10 @@
 package com.example.recipeapp.data
 
-import android.content.Context
-import android.content.Context.MODE_PRIVATE
-import android.content.SharedPreferences
-import com.example.recipeapp.PREF_FAVORITE_KEY
-import com.example.recipeapp.PREF_FILE_NAME
 import com.example.recipeapp.model.Category
 import com.example.recipeapp.model.Recipe
 
 class RecipeRepository(
     private val recipe: STUB = STUB,
-    private val context: Context
 ) {
 
     private val category = recipe.getCategories()
@@ -30,18 +24,5 @@ class RecipeRepository(
 
     fun getRecipesByIds(favoritesListIdInt: Set<Int>): List<Recipe> {
         return burgerRecipes.filter { favoritesListIdInt.contains(it.id) }
-    }
-
-    fun getFavorites(): MutableSet<String> {
-        val sharedPref: SharedPreferences = context.getSharedPreferences(PREF_FILE_NAME, MODE_PRIVATE)
-        val setId = sharedPref.getStringSet(PREF_FAVORITE_KEY, emptySet())
-        val mutableSteId = HashSet<String>(setId)
-        return mutableSteId
-    }
-
-    fun setFavorites(setFavoriteId: Set<String>?) {
-        val sharedPref:SharedPreferences = context.getSharedPreferences(PREF_FILE_NAME, MODE_PRIVATE)
-            ?: return
-        sharedPref.edit()?.putStringSet(PREF_FAVORITE_KEY, setFavoriteId)?.apply()
     }
 }

--- a/app/src/main/java/com/example/recipeapp/data/recipes.kt
+++ b/app/src/main/java/com/example/recipeapp/data/recipes.kt
@@ -239,12 +239,4 @@ object STUB {
     fun getCategories() = categories
 
     fun getRecipe() = burgerRecipes
-
-    fun getRecipeById(id: Int?): Recipe? {
-        return burgerRecipes.find { it.id == id }
-    }
-
-    fun getRecipesByIds(favoritesListIdInt: Set<Int>): List<Recipe> {
-        return burgerRecipes.filter { favoritesListIdInt.contains(it.id) }
-    }
 }

--- a/app/src/main/java/com/example/recipeapp/ui/categories/CategoriesListAdapter.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/categories/CategoriesListAdapter.kt
@@ -13,7 +13,7 @@ import com.example.recipeapp.databinding.ItemCategoryBinding
 import com.example.recipeapp.model.Category
 import java.io.InputStream
 
-class CategoriesListAdapter(private val dataSet: List<Category>) :
+class CategoriesListAdapter(var dataSet: List<Category>) :
     RecyclerView.Adapter<CategoriesListAdapter.ViewHolder>() {
 
     interface OnItemClickListener {

--- a/app/src/main/java/com/example/recipeapp/ui/categories/CategoriesListFragment.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/categories/CategoriesListFragment.kt
@@ -9,7 +9,7 @@ import androidx.core.os.bundleOf
 import androidx.fragment.app.commit
 import androidx.fragment.app.replace
 import androidx.fragment.app.viewModels
-import com.example.recipeapp.ARG_CATEGORY_ID
+import com.example.recipeapp.Constants.ARG_CATEGORY_ID
 import com.example.recipeapp.R
 import com.example.recipeapp.ui.recipes.listRecipes.RecipesListFragment
 import com.example.recipeapp.databinding.FragmentListCategoriesBinding

--- a/app/src/main/java/com/example/recipeapp/ui/categories/CategoriesListFragment.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/categories/CategoriesListFragment.kt
@@ -8,15 +8,15 @@ import android.view.ViewGroup
 import androidx.core.os.bundleOf
 import androidx.fragment.app.commit
 import androidx.fragment.app.replace
+import androidx.fragment.app.viewModels
 import com.example.recipeapp.ARG_CATEGORY_ID
-import com.example.recipeapp.ARG_CATEGORY_IMAGE_URL
-import com.example.recipeapp.ARG_CATEGORY_NAME
 import com.example.recipeapp.R
 import com.example.recipeapp.ui.recipes.listRecipes.RecipesListFragment
-import com.example.recipeapp.data.STUB
 import com.example.recipeapp.databinding.FragmentListCategoriesBinding
 
 class CategoriesListFragment : Fragment() {
+
+    private val viewModel: CategoryListViewModel by viewModels()
 
     private val categoriesListBinding:
             FragmentListCategoriesBinding by lazy {
@@ -29,18 +29,24 @@ class CategoriesListFragment : Fragment() {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-
         return categoriesListBinding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        initRecycler()
+        initUi()
     }
 
-    private fun initRecycler() {
-        val customAdapter = CategoriesListAdapter(STUB.getCategories())
+    private fun initUi() {
+
+        viewModel.loadCategoryList()
+
+        val customAdapter = CategoriesListAdapter(emptyList())
         categoriesListBinding.rvCategories.adapter = customAdapter
+
+        viewModel.categoryListState.observe(viewLifecycleOwner) { state ->
+            customAdapter.dataSet = state.categoryList
+        }
         customAdapter.setOnItemClickListener(
             object : CategoriesListAdapter.OnItemClickListener {
                 override fun onItemClick(categoryId: Int) {
@@ -51,14 +57,9 @@ class CategoriesListFragment : Fragment() {
     }
 
     private fun openRecipesByCategoryId(categoryId: Int) {
-        val category = STUB.getCategories()
-        val categoryName: String = category.first { it.id == categoryId }.title
-        val categoryImageUrl: String = category.first { it.id == categoryId }.imageUrl
 
         val bundle = bundleOf(
             ARG_CATEGORY_ID to categoryId,
-            ARG_CATEGORY_NAME to categoryName,
-            ARG_CATEGORY_IMAGE_URL to categoryImageUrl,
         )
         parentFragmentManager.commit {
             setReorderingAllowed(true)

--- a/app/src/main/java/com/example/recipeapp/ui/categories/CategoryListViewModel.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/categories/CategoryListViewModel.kt
@@ -1,18 +1,14 @@
 package com.example.recipeapp.ui.categories
 
-import android.app.Application
-import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.example.recipeapp.data.RecipeRepository
-import com.example.recipeapp.data.STUB
 import com.example.recipeapp.model.Category
-import com.example.recipeapp.ui.recipes.recipe.RecipeViewModel.RecipeUiState
 
-class CategoryListViewModel(application: Application) : AndroidViewModel(application) {
+class CategoryListViewModel() : ViewModel() {
 
-    private val repository = RecipeRepository(context = application)
+    private val repository = RecipeRepository()
 
     private val _categoryListState = MutableLiveData(CategoryListUiState())
     val categoryListState: LiveData<CategoryListUiState> get() = _categoryListState

--- a/app/src/main/java/com/example/recipeapp/ui/categories/CategoryListViewModel.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/categories/CategoryListViewModel.kt
@@ -1,0 +1,28 @@
+package com.example.recipeapp.ui.categories
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.example.recipeapp.data.RecipeRepository
+import com.example.recipeapp.data.STUB
+import com.example.recipeapp.model.Category
+import com.example.recipeapp.ui.recipes.recipe.RecipeViewModel.RecipeUiState
+
+class CategoryListViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val repository = RecipeRepository(context = application)
+
+    private val _categoryListState = MutableLiveData(CategoryListUiState())
+    val categoryListState: LiveData<CategoryListUiState> get() = _categoryListState
+
+    fun loadCategoryList() {
+        val categoryList = repository.getCategories()
+        _categoryListState.value = categoryListState.value?.copy(categoryList = categoryList)
+    }
+}
+
+data class CategoryListUiState(
+    val categoryList: List<Category> = emptyList()
+)

--- a/app/src/main/java/com/example/recipeapp/ui/recipes/favorites/FavoritesFragment.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/favorites/FavoritesFragment.kt
@@ -42,9 +42,13 @@ class FavoritesFragment : Fragment() {
         favoriteFragmentBinding.rvRecipeFavoritesList.adapter = customAdapter
 
         viewModel.favoritesState.observe(viewLifecycleOwner) { state ->
-            favoriteFragmentBinding.tvEmptyFavoriteList.text = state.messageText
-            favoriteFragmentBinding.tvEmptyFavoriteList.visibility = state.visibilityText
-            customAdapter.dataSet = state.favoritesSet
+            if (state.favoritesSet.isEmpty()) {
+                favoriteFragmentBinding.tvEmptyFavoriteList.text =
+                    getString(R.string.empty_favorite_list_message)
+            } else {
+                favoriteFragmentBinding.tvEmptyFavoriteList.visibility = View.GONE
+                customAdapter.dataSet = state.favoritesSet
+            }
         }
         customAdapter.setOnItemClickListener(
             object : RecipeListAdapter.OnItemClickListener {

--- a/app/src/main/java/com/example/recipeapp/ui/recipes/favorites/FavoritesFragment.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/favorites/FavoritesFragment.kt
@@ -9,7 +9,7 @@ import androidx.core.os.bundleOf
 import androidx.fragment.app.commit
 import androidx.fragment.app.replace
 import androidx.fragment.app.viewModels
-import com.example.recipeapp.ARG_RECIPE_ID
+import com.example.recipeapp.Constants.ARG_RECIPE_ID
 import com.example.recipeapp.R
 import com.example.recipeapp.ui.recipes.recipe.RecipeFragment
 import com.example.recipeapp.ui.recipes.listRecipes.RecipeListAdapter

--- a/app/src/main/java/com/example/recipeapp/ui/recipes/favorites/FavoritesViewModel.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/favorites/FavoritesViewModel.kt
@@ -1,32 +1,27 @@
 package com.example.recipeapp.ui.recipes.favorites
 
 import android.app.Application
-import android.content.Context.MODE_PRIVATE
-import android.view.View
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import com.example.recipeapp.PREF_FAVORITE_KEY
-import com.example.recipeapp.PREF_FILE_NAME
+import com.example.recipeapp.data.FavoritesLocalDataSources
+import com.example.recipeapp.data.FavoritesRepository
 import com.example.recipeapp.data.RecipeRepository
-import com.example.recipeapp.data.STUB
 import com.example.recipeapp.model.Recipe
-
-private const val MESSAGE_EMPTY_FAVORITE_LIST = "Вы еще не добавили ни одного рецепта в избранное"
 
 class FavoritesViewModel(private val application: Application) : AndroidViewModel(application) {
 
-    private val repository = RecipeRepository(context = application)
+    private val recipeRepository = RecipeRepository()
+    private val favoritesRepository = FavoritesRepository(FavoritesLocalDataSources((application)))
 
     private val _favoritesState = MutableLiveData(FavoritesUiState())
     val favoritesState: LiveData<FavoritesUiState> get() = _favoritesState
 
     fun loadFavoritesList() {
-        val favoritesRecipeSetId = repository.getFavorites().map { it.toInt() }.toSet()
-        val favoriteRecipeList = repository.getRecipesByIds(favoritesRecipeSetId)
+        val favoritesRecipeSetId = favoritesRepository.getRecipeData().map { it.toInt() }.toSet()
+        val favoriteRecipeList = recipeRepository.getRecipesByIds(favoritesRecipeSetId)
         if (favoriteRecipeList.isNotEmpty()) {
             _favoritesState.value = favoritesState.value?.copy(
-                visibilityText = View.GONE,
                 favoritesSet = favoriteRecipeList
             )
         }
@@ -35,6 +30,4 @@ class FavoritesViewModel(private val application: Application) : AndroidViewMode
 
 data class FavoritesUiState(
     val favoritesSet: List<Recipe> = emptyList(),
-    val visibilityText: Int = View.VISIBLE,
-    val messageText: String = MESSAGE_EMPTY_FAVORITE_LIST
-)
+    )

--- a/app/src/main/java/com/example/recipeapp/ui/recipes/favorites/FavoritesViewModel.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/favorites/FavoritesViewModel.kt
@@ -1,9 +1,11 @@
 package com.example.recipeapp.ui.recipes.favorites
 
 import android.app.Application
+import android.content.Context.MODE_PRIVATE
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import com.example.recipeapp.Constants.PREF_FILE_NAME
 import com.example.recipeapp.data.FavoritesLocalDataSources
 import com.example.recipeapp.data.FavoritesRepository
 import com.example.recipeapp.data.RecipeRepository
@@ -12,7 +14,13 @@ import com.example.recipeapp.model.Recipe
 class FavoritesViewModel(private val application: Application) : AndroidViewModel(application) {
 
     private val recipeRepository = RecipeRepository()
-    private val favoritesRepository = FavoritesRepository(FavoritesLocalDataSources((application)))
+    private val favoritesRepository = FavoritesRepository(
+        FavoritesLocalDataSources(
+            (application.getSharedPreferences(
+                PREF_FILE_NAME, MODE_PRIVATE
+            ))
+        )
+    )
 
     private val _favoritesState = MutableLiveData(FavoritesUiState())
     val favoritesState: LiveData<FavoritesUiState> get() = _favoritesState
@@ -27,7 +35,6 @@ class FavoritesViewModel(private val application: Application) : AndroidViewMode
         }
     }
 }
-
 data class FavoritesUiState(
     val favoritesSet: List<Recipe> = emptyList(),
-    )
+)

--- a/app/src/main/java/com/example/recipeapp/ui/recipes/favorites/FavoritesViewModel.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/favorites/FavoritesViewModel.kt
@@ -1,0 +1,40 @@
+package com.example.recipeapp.ui.recipes.favorites
+
+import android.app.Application
+import android.content.Context.MODE_PRIVATE
+import android.view.View
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.example.recipeapp.PREF_FAVORITE_KEY
+import com.example.recipeapp.PREF_FILE_NAME
+import com.example.recipeapp.data.RecipeRepository
+import com.example.recipeapp.data.STUB
+import com.example.recipeapp.model.Recipe
+
+private const val MESSAGE_EMPTY_FAVORITE_LIST = "Вы еще не добавили ни одного рецепта в избранное"
+
+class FavoritesViewModel(private val application: Application) : AndroidViewModel(application) {
+
+    private val repository = RecipeRepository(context = application)
+
+    private val _favoritesState = MutableLiveData(FavoritesUiState())
+    val favoritesState: LiveData<FavoritesUiState> get() = _favoritesState
+
+    fun loadFavoritesList() {
+        val favoritesRecipeSetId = repository.getFavorites().map { it.toInt() }.toSet()
+        val favoriteRecipeList = repository.getRecipesByIds(favoritesRecipeSetId)
+        if (favoriteRecipeList.isNotEmpty()) {
+            _favoritesState.value = favoritesState.value?.copy(
+                visibilityText = View.GONE,
+                favoritesSet = favoriteRecipeList
+            )
+        }
+    }
+}
+
+data class FavoritesUiState(
+    val favoritesSet: List<Recipe> = emptyList(),
+    val visibilityText: Int = View.VISIBLE,
+    val messageText: String = MESSAGE_EMPTY_FAVORITE_LIST
+)

--- a/app/src/main/java/com/example/recipeapp/ui/recipes/listRecipes/RecipeListAdapter.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/listRecipes/RecipeListAdapter.kt
@@ -13,7 +13,7 @@ import com.example.recipeapp.databinding.ItemRecipeBinding
 import com.example.recipeapp.model.Recipe
 import java.io.InputStream
 
-class RecipeListAdapter(private val dataSet: List<Recipe>) :
+class RecipeListAdapter(var dataSet: List<Recipe>) :
     RecyclerView.Adapter<RecipeListAdapter.ViewHolder>() {
 
     interface OnItemClickListener {

--- a/app/src/main/java/com/example/recipeapp/ui/recipes/listRecipes/RecipeListViewModel.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/listRecipes/RecipeListViewModel.kt
@@ -7,7 +7,6 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.example.recipeapp.data.RecipeRepository
-import com.example.recipeapp.data.STUB
 import com.example.recipeapp.model.Recipe
 import java.io.InputStream
 
@@ -15,7 +14,7 @@ class RecipeListViewModel(
     private val application: Application
 ) : AndroidViewModel(application) {
 
-    private val repository = RecipeRepository(context = application)
+    private val repository = RecipeRepository()
 
     private val _recipeListState = MutableLiveData(RecipeListUiState())
     val recipeListState: LiveData<RecipeListUiState> get() = _recipeListState

--- a/app/src/main/java/com/example/recipeapp/ui/recipes/listRecipes/RecipeListViewModel.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/listRecipes/RecipeListViewModel.kt
@@ -1,0 +1,50 @@
+package com.example.recipeapp.ui.recipes.listRecipes
+
+import android.app.Application
+import android.graphics.drawable.Drawable
+import android.util.Log
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.example.recipeapp.data.RecipeRepository
+import com.example.recipeapp.data.STUB
+import com.example.recipeapp.model.Recipe
+import java.io.InputStream
+
+class RecipeListViewModel(
+    private val application: Application
+) : AndroidViewModel(application) {
+
+    private val repository = RecipeRepository(context = application)
+
+    private val _recipeListState = MutableLiveData(RecipeListUiState())
+    val recipeListState: LiveData<RecipeListUiState> get() = _recipeListState
+
+    fun loadRecipeList(categoryId: Int?) {
+        val category = repository.getCategoryById(categoryId)
+        var drawable: Drawable? = null
+        try {
+            val inputStream: InputStream? =
+                application.assets?.open("${category?.imageUrl}")
+            drawable = Drawable.createFromStream(inputStream, null)
+        } catch (e: Exception) {
+            Log.e("!!!", e.stackTrace.toString())
+        }
+        _recipeListState.value = recipeListState.value?.copy(
+            titleImg = drawable,
+            titleText = category?.title,
+            recipeList = getRecipesByCategoryId(categoryId)
+        )
+    }
+
+    private fun getRecipesByCategoryId(categoryId: Int?): List<Recipe> {
+        val listRecipe = repository.getRecipe()
+        return if (categoryId == 0) listRecipe else emptyList()
+    }
+}
+
+data class RecipeListUiState(
+    val titleImg: Drawable? = null,
+    val titleText: String? = null,
+    val recipeList: List<Recipe> = emptyList()
+)

--- a/app/src/main/java/com/example/recipeapp/ui/recipes/listRecipes/RecipesListFragment.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/listRecipes/RecipesListFragment.kt
@@ -9,8 +9,8 @@ import androidx.core.os.bundleOf
 import androidx.fragment.app.commit
 import androidx.fragment.app.replace
 import androidx.fragment.app.viewModels
-import com.example.recipeapp.ARG_CATEGORY_ID
-import com.example.recipeapp.ARG_RECIPE_ID
+import com.example.recipeapp.Constants.ARG_CATEGORY_ID
+import com.example.recipeapp.Constants.ARG_RECIPE_ID
 import com.example.recipeapp.R
 import com.example.recipeapp.ui.recipes.recipe.RecipeFragment
 import com.example.recipeapp.databinding.FragmentRecipesListBinding

--- a/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/RecipeFragment.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/RecipeFragment.kt
@@ -1,20 +1,15 @@
 package com.example.recipeapp.ui.recipes.recipe
 
-import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.SeekBar
-import android.widget.SeekBar.OnSeekBarChangeListener
-import androidx.core.view.setPadding
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import com.example.recipeapp.ARG_RECIPE_ID
 import com.example.recipeapp.R
-import com.example.recipeapp.data.STUB
 import com.example.recipeapp.databinding.FragmentRecipeBinding
-import com.example.recipeapp.model.Ingredient
 import com.google.android.material.divider.MaterialDividerItemDecoration
 
 class RecipeFragment : Fragment() {
@@ -106,7 +101,6 @@ class RecipeFragment : Fragment() {
         recyclerViewIngredient.addItemDecoration(divider)
         recyclerViewMethod.addItemDecoration(divider)
     }
-
 }
 
 class PortionSeekBarListener(

--- a/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/RecipeFragment.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/RecipeFragment.kt
@@ -7,7 +7,7 @@ import android.view.ViewGroup
 import android.widget.SeekBar
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import com.example.recipeapp.ARG_RECIPE_ID
+import com.example.recipeapp.Constants.ARG_RECIPE_ID
 import com.example.recipeapp.R
 import com.example.recipeapp.databinding.FragmentRecipeBinding
 import com.google.android.material.divider.MaterialDividerItemDecoration


### PR DESCRIPTION
Иван, привет!
Статью почитал, что мог осилить, постарался применить. В частности, я так понимаю, что однонаправленный поток данных это: Репозиторий(где мы получаем данные и можем произвести над ними какие то действия)  -> ViewModel(где на основании этих данных формируется стейт) -> Фрагмент(где эти данные отображаются пользователю).

Вроде все сделал и все работает как и было. НО.
Не нужно ли было SharePreferences вынести в отдельный репозиторий? Вроде как сущность то одна, рецепты, а источники разнsе!
Контекст, смущает то что я из каждой Вью модели закидываю контекст для репозитория. Наверное в репозитории можно как то по другому получить его? Пытался искать, чет не знаю как вопрос задать в гугл. Выдает все для активити и фрагмента. Пока реализовал так.
Еще смущает инициализация STUB в конструкторе репозитория, не знаю почему, но как то кажется не правильно это что ли.
Ну вобщем пока так. Статью еще буду читать, много не знакомых слов там есть, думаю со временем станет все более ясным!